### PR TITLE
Replace match with if let where appropriate

### DIFF
--- a/src/projects/api.rs
+++ b/src/projects/api.rs
@@ -74,72 +74,62 @@ fn get_env_vars() -> Vec<(String, String)> {
 // I was getting bogged down on building up the command according to the platform, so...
 fn check_heroku_cli_windows() {
     prompt(TaskType::Manual, "Checking heroku-cli");
-    match std::process::Command::new("cmd")
+
+    if let Err(_) = std::process::Command::new("cmd")
         .args(&["/C", "heroku"])
         .stdout(std::process::Stdio::null())
         .status()
     {
-        Ok(_) => {}
-        Err(_) => {
-            println!("heroku-cli not found. Please install and try again: https://devcenter.heroku.com/articles/heroku-cli");
-            std::process::exit(1);
-        }
-    };
+        println!("heroku-cli not found. Please install and try again: https://devcenter.heroku.com/articles/heroku-cli");
+        std::process::exit(1);
+    }
 
-    match std::process::Command::new("cmd")
+    if !std::process::Command::new("cmd")
         .args(&["/C", "heroku", "auth:whoami"])
         .status()
         .expect("Could not confirm login")
         .success()
     {
-        true => {}
-        false => {
-            let status = std::process::Command::new("cmd")
-                .args(&["/C", "heroku", "login"])
-                .spawn()
-                .expect("Could not log in user.")
-                .wait()
-                .expect("??");
+        let status = std::process::Command::new("cmd")
+            .args(&["/C", "heroku", "login"])
+            .spawn()
+            .expect("Could not log in user.")
+            .wait()
+            .expect("??");
 
-            if !status.success() {
-                std::process::exit(1);
-            }
+        if !status.success() {
+            std::process::exit(1);
         }
-    };
+    }
 }
 
 // Checks if heroku-cli is installed, and  then  checks if user is logged in.
 fn check_heroku_cli() {
     prompt(TaskType::Manual, "Checking heroku-cli");
-    match std::process::Command::new("heroku")
+
+    if let Err(_) = std::process::Command::new("heroku")
         .stdout(std::process::Stdio::null())
         .status()
     {
-        Ok(_) => {}
-        Err(_) => {
-            println!("heroku-cli not found. Please install and try again: https://devcenter.heroku.com/articles/heroku-cli");
-            std::process::exit(1);
-        }
-    };
+        println!("heroku-cli not found. Please install and try again: https://devcenter.heroku.com/articles/heroku-cli");
+        std::process::exit(1);
+    }
 
-    match std::process::Command::new("heroku")
+    if !std::process::Command::new("heroku")
         .arg("auth:whoami")
         .status()
         .expect("Could not confirm login")
         .success()
     {
-        true => {}
-        false => {
-            let status = std::process::Command::new("heroku")
-                .arg("login")
-                .spawn()
-                .expect("Could not log in user.")
-                .wait()
-                .expect("??");
+        let status = std::process::Command::new("heroku")
+            .arg("login")
+            .spawn()
+            .expect("Could not log in user.")
+            .wait()
+            .expect("??");
 
-            if !status.success() {
-                std::process::exit(1);
-            }
+        if !status.success() {
+            std::process::exit(1);
         }
-    };
+    }
 }


### PR DESCRIPTION
Hm, this is a bit of personal preference I guess.
We had a bunch of `match` blocks where we only care about one specific value, so I turned them into [`if let`s](https://doc.rust-lang.org/book/ch06-03-if-let.html). It took me a bit to wrap my head around it, but it helped to think of it like I'm destructuring the value:

```
if let Err(_) = std::process::Command::new("heroku") {
}
```

If `std::process::Command::new("heroku")` is an `Err` (we don't care for the contents), the `let` binding is successful and the`if` block will execute.