### PR TITLE
Extract prompt utility

### DIFF
--- a/src/projects/api.rs
+++ b/src/projects/api.rs
@@ -1,3 +1,4 @@
+use crate::utils::{prompt, TaskType};
 use git2::Repository;
 use process::ExitStatus;
 use std::{path::PathBuf, process};
@@ -54,7 +55,7 @@ pub fn deploy_api_documentation(mut dir: &mut PathBuf) -> Result<ExitStatus, std
     }
     clone_repos(&mut dir).unwrap();
 
-    println!("Installing node dependencies");
+    prompt(TaskType::Automated, "Installing node dependencies");
     dir.push("ember-jsonapi-docs");
     process::Command::new("yarn")
         .current_dir(&dir)
@@ -62,7 +63,7 @@ pub fn deploy_api_documentation(mut dir: &mut PathBuf) -> Result<ExitStatus, std
         .expect("Could not install dependencies")
         .wait()?;
 
-    println!("🤖 Generating API documentation…");
+    prompt(TaskType::Automated, "Generating API documentation…");
     let vars = get_env_vars();
     let result = process::Command::new("yarn")
         .current_dir(&dir)
@@ -79,7 +80,7 @@ pub fn deploy_api_documentation(mut dir: &mut PathBuf) -> Result<ExitStatus, std
 // Checks if heroku-cli is installed, and  then  checks if user is logged in.
 // I was getting bogged down on building up the command according to the platform, so...
 fn check_heroku_cli_windows() {
-    println!("👩‍💻 Checking heroku-cli");
+    prompt(TaskType::Manual, "Checking heroku-cli");
     match std::process::Command::new("cmd")
         .args(&["/C", "heroku"])
         .stdout(std::process::Stdio::null())
@@ -116,7 +117,7 @@ fn check_heroku_cli_windows() {
 
 // Checks if heroku-cli is installed, and  then  checks if user is logged in.
 fn check_heroku_cli() {
-    println!("👩‍💻 Checking heroku-cli");
+    prompt(TaskType::Manual, "Checking heroku-cli");
     match std::process::Command::new("heroku")
         .stdout(std::process::Stdio::null())
         .status()

--- a/src/projects/guides.rs
+++ b/src/projects/guides.rs
@@ -1,4 +1,4 @@
-use crate::utils::{pause, read_input};
+use crate::utils::{prompt, TaskType};
 use git2::Repository;
 use process::ExitStatus;
 use std::{path::PathBuf, process};
@@ -14,12 +14,14 @@ fn clone_repos(folder: &mut PathBuf) -> Result<Repository, git2::Error> {
 
 pub fn deploy_guides(mut dir: &mut PathBuf) -> Result<ExitStatus, std::io::Error> {
     println!("Beginning deploy for: Guides\n");
-    println!("👩‍💻 Check for pending PRs: https://github.com/ember-learn/guides-source/pulls");
-    pause();
+    prompt(
+        TaskType::Manual,
+        "Check for pending PRs: https://github.com/ember-learn/guides-source/pulls",
+    );
 
     clone_repos(&mut dir).unwrap();
 
-    println!("🤖 Installing node dependencies");
+    prompt(TaskType::Automated, "Installing node dependencies");
     dir.push("guides-source");
     process::Command::new("npm")
         .current_dir(&dir)
@@ -28,7 +30,7 @@ pub fn deploy_guides(mut dir: &mut PathBuf) -> Result<ExitStatus, std::io::Error
         .expect("Could not install dependencies")
         .wait()?;
 
-    println!("🤖 Creating new version of guides");
+    prompt(TaskType::Automated, "Creating new version of guides");
     process::Command::new("npm")
         .current_dir(&dir)
         .arg("run")
@@ -37,13 +39,13 @@ pub fn deploy_guides(mut dir: &mut PathBuf) -> Result<ExitStatus, std::io::Error
         .expect("Failed to release guides.")
         .wait()?;
 
-    println!("👩‍💻 Confirm new guides version is deployed before proceeding");
-    pause();
+    prompt(
+        TaskType::Manual,
+        "Confirm new guides version is deployed before proceeding",
+    );
+    prompt(TaskType::Manual, "You are super duper sure it's deployed?");
+    prompt(TaskType::Automated, "Publishing Algolia index");
 
-    println!("👩‍💻 You are super duper sure it's deployed?");
-    pause();
-
-    println!("🤖 Publishing algolia index");
     process::Command::new("npm")
         .arg("run")
         .arg("release:search")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,3 +23,27 @@ pub fn pause() {
     // Read a single byte and discard
     let _ = stdin.read(&mut [0u8]).unwrap();
 }
+
+use std::fmt::Display;
+
+pub enum TaskType {
+    Automated,
+    Manual,
+}
+
+impl Display for TaskType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TaskType::Automated => write!(f, "🤖"),
+            TaskType::Manual => write!(f, "👩‍💻"),
+        }
+    }
+}
+
+pub fn prompt(task_type: TaskType, description: &str) {
+    println!("{} {}", task_type, description);
+    if let TaskType::Manual = task_type {
+        crate::utils::pause();
+    }
+    print!("\n");
+}


### PR DESCRIPTION
While working on the codebase, I noticed that I would always pause after prompting for manual tasks, so I thought I'd encapsulate that logic in a `prompt` utility.
I've also added an enum for the manual/automated task types so I didn't have to keep copy pasting the respective emoji. I then use this enum to conditionally pause if it's a manual task, and the Display implementation takes care of serializing the enum into a string.