### PR TITLE
Clean up 1password-cli integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tool-new-release"
 version = "0.1.0"
 dependencies = [
@@ -1239,6 +1248,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempfile",
+ "toml",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ semver = "0.11.0"
 serde_json = "1.0.61"
 serde = { version = "1.0.118", features = ["derive"] }
 chrono = "0.4.19"
+toml = "0.5.9"

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -6,7 +6,7 @@ pub fn github(
     organization: &str,
     project: &str,
 ) -> (git2::Repository, PathBuf) {
-    let src = format!("https://github.com/{}/{}.git", organization, project);
+    let src = format!("https://git@github.com/{}/{}.git", organization, project);
     automated(format!("Cloning {}", src).as_str());
 
     crate::git::clone::clone(root, src)

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -6,7 +6,7 @@ pub fn github(
     organization: &str,
     project: &str,
 ) -> (git2::Repository, PathBuf) {
-    let src = format!("git@github.com:{}/{}.git", organization, project);
+    let src = format!("https://github.com/{}/{}.git", organization, project);
     automated(format!("Cloning {}", src).as_str());
 
     crate::git::clone::clone(root, src)

--- a/src/git/clone.rs
+++ b/src/git/clone.rs
@@ -1,32 +1,8 @@
-use git2::{Cred, RemoteCallbacks};
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 use tempfile::tempdir_in;
 
 pub fn clone(root: &Path, src: String) -> (git2::Repository, PathBuf) {
-    let mut callbacks = RemoteCallbacks::new();
-    callbacks.credentials(|_url, username_from_url, _allowed_types| {
-        Cred::ssh_key(
-            username_from_url.unwrap(),
-            None,
-            Path::new(&format!("{}/.ssh/id_rsa", env::var("HOME").unwrap())),
-            None,
-        )
-    });
-
-    // Prepare fetch options.
-    let mut fo = git2::FetchOptions::new();
-    fo.remote_callbacks(callbacks);
-
-    // Prepare builder.
-    let mut builder = git2::build::RepoBuilder::new();
-    builder.fetch_options(fo);
-
     let dir = tempdir_in(root).unwrap().into_path();
-    let repo = builder.clone(src.as_str(), &dir).unwrap();
-
-    // let repo = git2::Repository::clone(src.as_str(), &dir).unwrap();
+    let repo = git2::Repository::clone(src.as_str(), &dir).unwrap();
     (repo, dir)
 }

--- a/src/projects/api.rs
+++ b/src/projects/api.rs
@@ -3,7 +3,7 @@ use crate::Opts;
 use std::process;
 
 pub fn run(dir: &std::path::Path, opts: &Opts) {
-    let vars = crate::utils::op::get_api_docs_vars();
+    let vars = crate::utils::op::api_docs::read();
     let (_, jsonapi_docs_dir) = crate::clone::github(dir, "ember-learn", "ember-jsonapi-docs");
 
     automated("Installing node dependencies");

--- a/src/projects/glitch.rs
+++ b/src/projects/glitch.rs
@@ -19,7 +19,7 @@ pub fn run(dir: &std::path::Path, opts: &crate::Opts, version: &Version) {
 
     if !opts.dry_run {
         automated("Cloning Glitch starter app");
-        let glitch_repo_url = crate::utils::op::get_glitch();
+        let glitch_repo_url = crate::utils::op::glitch::read();
         let (glitch_repo, glitch_dir) = crate::git::clone::clone(dir, glitch_repo_url);
 
         automated("Updating Glitch app with content from ember-new-output");
@@ -73,7 +73,7 @@ fn download_ember_new(version: &str) -> PathBuf {
 
     let response = reqwest::blocking::get(&zip_url).expect("Could not download ember-new-output");
     if !response.status().is_success() {
-        println!("Could not find zip file for {}", &version);
+        eprintln!("Could not find zip file for {}", &version);
         std::process::exit(-1);
     }
     let zip = response.bytes().unwrap();


### PR DESCRIPTION
The tool will now:
- Check if `op` is available. If not and the user is on macOS, it will try to install using Homebrew.
- Log user in
- Read `op` data through "secret references"