### PR TITLE
add m1 support to release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
       matrix:
         include:
           - os: macos-latest
+            target: aarch64-apple-darwin
+            suffix: ''
+          - os: macos-latest
             target: x86_64-apple-darwin
             suffix: ''
           - os: ubuntu-latest


### PR DESCRIPTION
I added a build for M1 architecture in #40 but I didn't notice that we have 2 separate CI files 🙈 this adds M1 support to the file that makes the build artifacts 